### PR TITLE
feat: support dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ USAGE:
    github-comment [global options] command [command options] [arguments...]
 
 VERSION:
-   1.5.1
+   1.8.0
 
 COMMANDS:
    post     post a comment
@@ -230,6 +230,7 @@ OPTIONS:
    --config value                  configuration file path
    --pr value                      GitHub pull request number (default: 0)
    --var value                     template variable
+   --dry-run                       output a comment to standard error output instead of posting to GitHub (default: false)
 ```
 
 ```
@@ -250,6 +251,7 @@ OPTIONS:
    --config value                  configuration file path
    --pr value                      GitHub pull request number (default: 0)
    --var value                     template variable
+   --dry-run                       output a comment to standard error output instead of posting to GitHub (default: false)
 ```
 
 ## Configuration

--- a/pkg/comment/mock.go
+++ b/pkg/comment/mock.go
@@ -1,0 +1,21 @@
+package comment
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+type Mock struct {
+	Stderr io.Writer
+}
+
+func (mock Mock) Create(ctx context.Context, cmt Comment) error {
+	msg := "[github-comment][DRYRUN] Comment to " + cmt.Org + "/" + cmt.Repo + " sha1:" + cmt.SHA1
+	if cmt.PRNumber != 0 {
+		msg += " issue:" + strconv.Itoa(cmt.PRNumber)
+	}
+	fmt.Fprintln(mock.Stderr, msg+"\n[github-comment][DRYRUN] "+cmt.Body)
+	return nil
+}

--- a/pkg/option/exec.go
+++ b/pkg/option/exec.go
@@ -15,6 +15,7 @@ type ExecOptions struct {
 	ConfigPath  string
 	Args        []string
 	Vars        map[string]string
+	DryRun      bool
 }
 
 func ValidateExec(opts ExecOptions) error {

--- a/pkg/option/post.go
+++ b/pkg/option/post.go
@@ -14,6 +14,7 @@ type PostOptions struct {
 	TemplateKey string
 	ConfigPath  string
 	Vars        map[string]string
+	DryRun      bool
 }
 
 func ValidatePost(opts PostOptions) error {


### PR DESCRIPTION
Close #83 

Add an option `-dry-run` to the commands `post` and `exec`.
When the option is set, the comment isn't posted to GitHub but outputted to the standard error output.

ex.

```
$ github-comment post -dry-run -template hello
[github-comment][DRYRUN] Comment to suzuki-shunsuke/github-comment sha1:xxx issue:10
[github-comment][DRYRUN] hello
```