### PR TITLE
feat: post a substitute comment when it is failed to post a too long comment

### DIFF
--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -149,6 +149,7 @@ func (ctrl ExecController) getComment(
 ) (comment.Comment, bool, error) {
 	cmt := comment.Comment{}
 	tpl := cmtParams.Template
+	tplForTooLong := ""
 	if tpl == "" {
 		execConfig, f, err := ctrl.getExecConfig(execConfigs, cmtParams)
 		if err != nil {
@@ -161,18 +162,24 @@ func (ctrl ExecController) getComment(
 			return cmt, false, nil
 		}
 		tpl = execConfig.Template
+		tplForTooLong = execConfig.TemplateForTooLong
 	}
 
 	body, err := ctrl.Renderer.Render(tpl, templates, cmtParams)
 	if err != nil {
 		return cmt, false, err
 	}
+	bodyForTooLong, err := ctrl.Renderer.Render(tplForTooLong, templates, cmtParams)
+	if err != nil {
+		return cmt, false, err
+	}
 	return comment.Comment{
-		PRNumber: cmtParams.PRNumber,
-		Org:      cmtParams.Org,
-		Repo:     cmtParams.Repo,
-		Body:     body,
-		SHA1:     cmtParams.SHA1,
+		PRNumber:       cmtParams.PRNumber,
+		Org:            cmtParams.Org,
+		Repo:           cmtParams.Repo,
+		Body:           body,
+		BodyForTooLong: bodyForTooLong,
+		SHA1:           cmtParams.SHA1,
 	}, true, nil
 }
 

--- a/pkg/api/init.go
+++ b/pkg/api/init.go
@@ -16,11 +16,13 @@ const cfgTemplate = `---
 # templates:
 #   header: "# {{.Org}}/{{.Repo}}"
 # post:
-#   default: |
-#     {{template "header" .}}
-#     {{.Vars.foo}} {{.Vars.zoo.foo}}
-#     {{.Org}} {{.Repo}} {{.PRNumber}} {{.SHA1}} {{.TemplateKey}}
-#   hello: hello
+#   default:
+#     template: |
+#       {{template "header" .}}
+#       {{.Vars.foo}} {{.Vars.zoo.foo}}
+#       {{.Org}} {{.Repo}} {{.PRNumber}} {{.SHA1}} {{.TemplateKey}}
+#   hello:
+#     template: hello
 # exec:
 #   hello:
 #     - when: true
@@ -50,6 +52,15 @@ const cfgTemplate = `---
 #
 #         ` + "```" + `
 #         {{.CombinedOutput}}
+#         ` + "```" + `
+#       template_for_too_long: |
+#         {{template "header" .}}
+#         {{.Vars.foo}} {{.Vars.zoo.foo}}
+#         {{.Org}} {{.Repo}} {{.PRNumber}} {{.SHA1}} {{.TemplateKey}}
+#         exit code: {{.ExitCode}}
+#
+#         ` + "```" + `
+#         $ {{.Command}}
 #         ` + "```" + `
 `
 

--- a/pkg/api/post_internal_test.go
+++ b/pkg/api/post_internal_test.go
@@ -92,8 +92,10 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				},
 				Reader: mockReader{
 					cfg: config.Config{
-						Post: map[string]string{
-							"default": "hello",
+						Post: map[string]config.PostConfig{
+							"default": {
+								Template: "hello",
+							},
 						},
 					},
 				},

--- a/pkg/option/exec.go
+++ b/pkg/option/exec.go
@@ -5,18 +5,19 @@ import (
 )
 
 type ExecOptions struct {
-	PRNumber    int
-	Org         string
-	Repo        string
-	Token       string
-	SHA1        string
-	Template    string
-	TemplateKey string
-	ConfigPath  string
-	Args        []string
-	Vars        map[string]string
-	DryRun      bool
-	SkipNoToken bool
+	PRNumber           int
+	Org                string
+	Repo               string
+	Token              string
+	SHA1               string
+	Template           string
+	TemplateForTooLong string
+	TemplateKey        string
+	ConfigPath         string
+	Args               []string
+	Vars               map[string]string
+	DryRun             bool
+	SkipNoToken        bool
 }
 
 func ValidateExec(opts ExecOptions) error {

--- a/pkg/option/post.go
+++ b/pkg/option/post.go
@@ -5,17 +5,18 @@ import (
 )
 
 type PostOptions struct {
-	PRNumber    int
-	Org         string
-	Repo        string
-	Token       string
-	SHA1        string
-	Template    string
-	TemplateKey string
-	ConfigPath  string
-	Vars        map[string]string
-	DryRun      bool
-	SkipNoToken bool
+	PRNumber           int
+	Org                string
+	Repo               string
+	Token              string
+	SHA1               string
+	Template           string
+	TemplateForTooLong string
+	TemplateKey        string
+	ConfigPath         string
+	Vars               map[string]string
+	DryRun             bool
+	SkipNoToken        bool
 }
 
 func ValidatePost(opts PostOptions) error {


### PR DESCRIPTION
Close #124 

When the comment is too long, it is failed to post a comment due to GitHub API's validation.

```json
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "IssueComment",
      "code": "unprocessable",
      "field": "data",
      "message": "Body is too long (maximum is 65536 characters)"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue-comment"
}
```

If a comment includes the long command standard output, you may encounter the error.

github-comment supports to post a substitute comment in that case.

When it is failed to post a comment of `template`, github-comment posts a comment of `template_for_too_long` instead of `template`.

ex.

```yaml
post:
  hello:
    template: too long comment
    template_for_too_long: comment is too long
exec:
  hello:
    - when: ExitCode != 0
      template: |
        exit code: {{.ExitCode}}
        combined output: {{.CombinedOutput}}
      template_for_too_long: |
        comment is too long so the command output is omitted
        exit code: {{.ExitCode}}
```