### PR TITLE
ci: fix unmarshaling of PostConfig

### DIFF
--- a/.github-comment.yml
+++ b/.github-comment.yml
@@ -2,8 +2,9 @@
 post:
   default: |
     CIRCLE_PULL_REQUEST: {{Env "CIRCLE_PULL_REQUEST"}}
-  hello: |
-    $Hello: {{Env "HELLO"}} {{ "hello!" | upper | repeat 5 }}
+  hello:
+    template: |
+      $Hello: {{Env "HELLO"}} {{ "hello!" | upper | repeat 5 }}
 exec:
   hello:
     - when: ExitCode != 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		pc.Template = s
 		return nil
 	}
-	if m, ok := val.(map[string]interface{}); ok { //nolint:nestif
+	if m, ok := val.(map[interface{}]interface{}); ok { //nolint:nestif
 		if tpl, ok := m["template"]; ok {
 			t, ok := tpl.(string)
 			if !ok {
@@ -52,6 +52,7 @@ func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			pc.TemplateForTooLong = t
 		}
+		return nil
 	}
 	return fmt.Errorf("invalid config. post config should be string or map[string]intterface{}: %+v", val)
 }


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/suzuki-shunsuke/github-comment/70/workflows/9c8ce42b-08b1-43e5-965a-3eedf8170089/jobs/65

```
+ go run ./cmd/github-comment post --dry-run -k hello
invalid config. post config should be string or map[string]intterface{}: map[template:$Hello: {{Env "HELLO"}} {{ "hello!" | upper | repeat 5 }}
]
exit status 1
```