### PR TITLE
feat: add a template function AvoidHTMLEscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ OPTIONS:
 * TemplateKey
 * Vars
 * Env: the function to get the environment variable https://golang.org/pkg/os/#Getenv
+* AvoidHTMLEscape: the function to post a comment without HTML escape by [Go's html/template](https://golang.org/pkg/html/template/)
 * Sprig Function: http://masterminds.github.io/sprig/
 
 ### exec

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -19,10 +19,15 @@ func addTemplates(tpl string, templates map[string]string) string {
 	return tpl
 }
 
+func avoidHTMLEscape(text string) template.HTML {
+	return template.HTML(text) //nolint:gosec
+}
+
 func (renderer Renderer) Render(tpl string, templates map[string]string, params interface{}) (string, error) {
 	tpl = addTemplates(tpl, templates)
 	tmpl, err := template.New("comment").Funcs(template.FuncMap{
-		"Env": renderer.Getenv,
+		"Env":             renderer.Getenv,
+		"AvoidHTMLEscape": avoidHTMLEscape,
 	}).Funcs(sprig.FuncMap()).Parse(tpl)
 	if err != nil {
 		return "", fmt.Errorf("parse a template: %w", err)


### PR DESCRIPTION
The following comment is escaped to `&lt;` by Go's html/template.

```
    template: |
      <
```

To comment `<`, use the function `AvoidHTMLEscape` like this.

```
    template: |
      {{ "<" | AvoidHTMLEscape }}
```