### PR TITLE
fix: define the template "link" always

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -22,12 +22,12 @@ func GetTemplates(templates map[string]string, ci string) map[string]string {
 		"hidden_combined_output": `<details><pre><code>{{.CombinedOutput | AvoidHTMLEscape}}</code></pre></details>`,
 	}
 
-	ret := map[string]string{}
+	ret := map[string]string{
+		"link": "",
+	}
 	if ci != "" {
 		if link, ok := buildLinks[ci]; ok {
 			ret["link"] = link
-		} else {
-			ret["link"] = ""
 		}
 	}
 	for k, v := range builtinTemplates {


### PR DESCRIPTION
## Problem to solve

If CI service isn't detected, the template "link" isn't defined.

```
github-comment error: render a comment template: render a template with params: html/template:comment:2:169: no such template "link"
```

## How to solve

Set an empty string to the template "link" if CI service isn't detected.