### PR TITLE
fix: add the option `-stdin-template` to post command

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ $ github-comment post -var name:foo
 
 ## post command supports standard input to pass a template
 
-Instead of `-template`, we can pass a template from a standard input.
+Instead of `-template`, we can pass a template from a standard input with `-stdin-template`.
 
 ```
-$ echo hello | github-comment post
+$ echo hello | github-comment post -stdin-template
 ```
 
 ## post a substitute comment when it is failed to post a too long comment

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -79,7 +79,7 @@ func (ctrl PostController) getCommentParams(opts option.PostOptions) (comment.Co
 			return cmt, fmt.Errorf("failed to complement opts with CircleCI built in environment variables: %w", err)
 		}
 	}
-	if opts.Template == "" {
+	if opts.Template == "" && opts.StdinTemplate {
 		tpl, err := ctrl.readTemplateFromStdin()
 		if err != nil {
 			return cmt, err

--- a/pkg/api/post_internal_test.go
+++ b/pkg/api/post_internal_test.go
@@ -33,10 +33,11 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Renderer: template.Renderer{},
 			},
 			opts: option.PostOptions{
-				Org:      "suzuki-shunsuke",
-				Repo:     "github-comment",
-				Token:    "xxx",
-				PRNumber: 1,
+				Org:           "suzuki-shunsuke",
+				Repo:          "github-comment",
+				Token:         "xxx",
+				PRNumber:      1,
+				StdinTemplate: true,
 			},
 			exp: comment.Comment{
 				Org:      "suzuki-shunsuke",
@@ -158,8 +159,9 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Renderer: template.Renderer{},
 			},
 			opts: option.PostOptions{
-				Token:    "xxx",
-				PRNumber: 1,
+				Token:         "xxx",
+				PRNumber:      1,
+				StdinTemplate: true,
 			},
 			exp: comment.Comment{
 				Org:      "suzuki-shunsuke",

--- a/pkg/cmd/post.go
+++ b/pkg/cmd/post.go
@@ -78,6 +78,10 @@ func (runner Runner) postCommand() cli.Command { //nolint:funlen,dupl
 				Aliases: []string{"s"},
 				Usage:   "suppress the output of dry-run and skip-no-token",
 			},
+			&cli.BoolFlag{
+				Name:  "stdin-template",
+				Usage: "read standard input as the template",
+			},
 		},
 	}
 }
@@ -107,6 +111,7 @@ func parsePostOptions(opts *option.PostOptions, c *cli.Context) error {
 	opts.DryRun = c.Bool("dry-run")
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
+	opts.StdinTemplate = c.Bool("stdin-template")
 	vars, err := parseVarsFlag(c.StringSlice("var"))
 	if err != nil {
 		return err

--- a/pkg/option/post.go
+++ b/pkg/option/post.go
@@ -18,6 +18,7 @@ type PostOptions struct {
 	DryRun             bool
 	SkipNoToken        bool
 	Silent             bool
+	StdinTemplate      bool
 }
 
 func ValidatePost(opts PostOptions) error {


### PR DESCRIPTION
Close #169

## BREAKING CHANGE: To read stdin as the template, we must specify the option `-stdin-template`

### AS IS

```
echo hello | github-comment post
```

From v2.0.0, in case of the above command, the standard input will be ignored and the `default` template will be used.

### TO BE

```
echo hello | github-comment post -stdin-template
```