### PR TITLE
Don't use <pre><code> tags in hidden_combined_output

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -19,7 +19,7 @@ func GetTemplates(templates map[string]string, ci string) map[string]string {
 	builtinTemplates := map[string]string{
 		"status":                 `:{{if eq .ExitCode 0}}white_check_mark{{else}}x{{end}}:`,
 		"join_command":           `<pre><code>$ {{.JoinCommand | AvoidHTMLEscape}}</pre></code>`,
-		"hidden_combined_output": `<details><pre><code>{{.CombinedOutput | AvoidHTMLEscape}}</code></pre></details>`,
+		"hidden_combined_output": "<details>\n```\n{{.CombinedOutput | AvoidHTMLEscape}}\n```\n</details>",
 	}
 
 	ret := map[string]string{


### PR DESCRIPTION
If the content of `.CombinedOutput` is Markdown-like,
it will be parsed as markdown and the posted comment will be ugly.

## As Is

<img width="453" alt="Slack | Unread Messages | Quipper 2021-01-06 16-44-07" src="https://user-images.githubusercontent.com/241542/103742623-7c632980-503e-11eb-9671-6c30fcead114.png">

## To Be

<img width="718" alt="Slack | Unread Messages | Quipper 2021-01-06 16-45-23" src="https://user-images.githubusercontent.com/241542/103742726-a4eb2380-503e-11eb-9911-a65f73b38cbe.png">
