### PR TITLE
fix: fix builtin template join_command and hidden_combined_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,15 +441,35 @@ They are overwritten if the same name templates are defined in the configuration
 
 ### templates.join_command
 
+If `.JoinCommand` includes \`\`\`,
+
 ```
 <pre><code>$ {{.JoinCommand | AvoidHTMLEscape}}</pre></code>
 ```
 
+Otherwise,
+
+<pre><code>```
+$ {{.JoinCommand | AvoidHTMLEscape}}
+```</pre></code>
+
 ### templates.hidden_combined_output
+
+If `.CombinedOutput` includes \`\`\` ,
 
 ```
 <details><pre><code>{{.CombinedOutput | AvoidHTMLEscape}}</code></pre></details>
 ```
+
+Otherwise,
+
+<pre><code>&lt;details&gt;
+
+```
+{{.CombinedOutput | AvoidHTMLEscape}}
+```
+
+&lt;/details&gt;</pre></code>
 
 ### templates.link
 

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -133,11 +133,17 @@ func (ctrl ExecController) Exec(ctx context.Context, opts option.ExecOptions) er
 	if ctrl.Platform != nil {
 		ci = ctrl.Platform.CI()
 	}
-	templates := template.GetTemplates(cfg.Templates, ci)
+	joinCommand := strings.Join(opts.Args, " ")
+	templates := template.GetTemplates(template.ParamGetTemplates{
+		Templates:      cfg.Templates,
+		CI:             ci,
+		JoinCommand:    joinCommand,
+		CombinedOutput: result.CombinedOutput,
+	})
 	if err := ctrl.post(ctx, execConfigs, ExecCommentParams{
 		ExitCode:       result.ExitCode,
 		Command:        result.Cmd,
-		JoinCommand:    strings.Join(opts.Args, " "),
+		JoinCommand:    joinCommand,
 		Stdout:         result.Stdout,
 		Stderr:         result.Stderr,
 		CombinedOutput: result.CombinedOutput,

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -120,7 +120,10 @@ func (ctrl PostController) getCommentParams(opts option.PostOptions) (comment.Co
 	if ctrl.Platform != nil {
 		ci = ctrl.Platform.CI()
 	}
-	templates := template.GetTemplates(cfg.Templates, ci)
+	templates := template.GetTemplates(template.ParamGetTemplates{
+		Templates: cfg.Templates,
+		CI:        ci,
+	})
 	tpl, err := ctrl.Renderer.Render(opts.Template, templates, PostTemplateParams{
 		PRNumber:    opts.PRNumber,
 		Org:         opts.Org,


### PR DESCRIPTION
Follow up #182 

### templates.join_command

If `.JoinCommand` includes \`\`\`,

```
<pre><code>$ {{.JoinCommand | AvoidHTMLEscape}}</pre></code>
```

Otherwise,

<pre><code>```
$ {{.JoinCommand | AvoidHTMLEscape}}
```</pre></code>
### templates.hidden_combined_output
If `.CombinedOutput` includes \`\`\` ,

```
<details><pre><code>{{.CombinedOutput | AvoidHTMLEscape}}</code></pre></details>
```

Otherwise,

<pre><code>&lt;details&gt;

```
{{.CombinedOutput | AvoidHTMLEscape}}
```

&lt;/details&gt;</pre></code>