### PR TITLE
fix: don't filter commits by login when login is empty

### DIFF
--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -74,7 +74,9 @@ func isExcludedComment(cmt comment.IssueComment, login string) bool {
 	if cmt.IsMinimized {
 		return true
 	}
-	if cmt.Author.Login != login {
+	// GitHub Actions's GITHUB_TOKEN secret doesn't have a permission to get an authenticated user.
+	// So if `login` is empty, we give up filtering comments by login.
+	if login != "" && cmt.Author.Login != login {
 		return true
 	}
 	return false


### PR DESCRIPTION
Follow up #189 

GitHub Actions's GITHUB_TOKEN secret doesn't have a permission to get an authenticated user.
So if `login` is empty, we give up filtering comments by login.