### PR TITLE
fix: ignore error to get an authenticated user

### DIFF
--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -97,7 +97,7 @@ func listHiddenComments( //nolint:funlen
 	}
 	login, err := commenter.GetAuthenticatedUser(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get an authenticated user: %w", err)
+		logrus.WithError(err).Warn("get an authenticated user")
 	}
 
 	comments, err := commenter.List(ctx, comment.PullRequest{


### PR DESCRIPTION
Follow up #189 