### PR TITLE
feat: add a command "hide" and embed meta data to comment

### DIFF
--- a/pkg/api/comment.go
+++ b/pkg/api/comment.go
@@ -63,15 +63,15 @@ func (ctrl *CommentController) complementMetaData(metadata map[string]interface{
 	}
 	switch ctrl.Platform.CI() {
 	case "circleci":
-		metadata["job_name"] = ctrl.Getenv("CIRCLE_JOB")
-		metadata["job_id"] = ctrl.Getenv("CIRCLE_WORKFLOW_JOB_ID")
+		metadata["JobName"] = ctrl.Getenv("CIRCLE_JOB")
+		metadata["JobID"] = ctrl.Getenv("CIRCLE_WORKFLOW_JOB_ID")
 	case "drone":
-		metadata["workflow_name"] = ctrl.Getenv("DRONE_STATE_NAME")
-		metadata["job_name"] = ctrl.Getenv("DRONE_STEP_NAME")
+		metadata["WorkflowName"] = ctrl.Getenv("DRONE_STATE_NAME")
+		metadata["JobName"] = ctrl.Getenv("DRONE_STEP_NAME")
 	case "github-actions":
-		metadata["workflow_name"] = ctrl.Getenv("GITHUB_WORKFLOW")
-		metadata["job_name"] = ctrl.Getenv("GITHUB_JOB")
+		metadata["WorkflowName"] = ctrl.Getenv("GITHUB_WORKFLOW")
+		metadata["JobName"] = ctrl.Getenv("GITHUB_JOB")
 	case "codebuild":
-		metadata["job_id"] = ctrl.Getenv("CODEBUILD_BUILD_ID")
+		metadata["JobID"] = ctrl.Getenv("CODEBUILD_BUILD_ID")
 	}
 }

--- a/pkg/api/comment.go
+++ b/pkg/api/comment.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/suzuki-shunsuke/github-comment/pkg/comment"
 )
 
@@ -26,52 +25,10 @@ type CommentController struct {
 }
 
 func (ctrl *CommentController) Post(ctx context.Context, cmt comment.Comment, hiddenParam map[string]interface{}) error {
-	logE := logrus.WithFields(logrus.Fields{
-		"program": "github-comment",
-	})
-	skipHideComment := false
-	nodeIDs, err := ctrl.listHiddenComments(ctx, cmt, hiddenParam)
-	if err != nil {
-		skipHideComment = true
-		logE.WithError(err).Error("list hidden comments")
-	}
 	if err := ctrl.Commenter.Create(ctx, cmt); err != nil {
 		return fmt.Errorf("failed to create an issue comment: %w", err)
 	}
-	if !skipHideComment {
-		logE.WithFields(logrus.Fields{
-			"count":    len(nodeIDs),
-			"node_ids": nodeIDs,
-		}).Debug("comments which would be hidden")
-		ctrl.hideComments(ctx, nodeIDs)
-	}
 	return nil
-}
-
-func (ctrl *CommentController) listHiddenComments(ctx context.Context, cmt comment.Comment, hiddenParam map[string]interface{}) ([]string, error) {
-	return listHiddenComments(
-		ctx, ctrl.Commenter, ctrl.Expr, ctrl.Getenv, cmt, hiddenParam)
-}
-
-func (ctrl *CommentController) hideComments(ctx context.Context, nodeIDs []string) {
-	hideComments(ctx, ctrl.Commenter, nodeIDs)
-}
-
-func hideComments(ctx context.Context, commenter Commenter, nodeIDs []string) {
-	logE := logrus.WithFields(logrus.Fields{
-		"program": "github-comment",
-	})
-	for _, nodeID := range nodeIDs {
-		if err := commenter.HideComment(ctx, nodeID); err != nil {
-			logE.WithError(err).WithFields(logrus.Fields{
-				"node_id": nodeID,
-			}).Error("hide an old comment")
-			continue
-		}
-		logE.WithFields(logrus.Fields{
-			"node_id": nodeID,
-		}).Debug("hide an old comment")
-	}
 }
 
 const (
@@ -92,117 +49,6 @@ func extractMetaFromComment(body string, metadata map[string]interface{}) bool {
 		if err := json.Unmarshal([]byte(line[lenEmbeddedCommentPrefix:len(line)-lenEmbeddedCommentSuffix]), &metadata); err != nil {
 			continue
 		}
-		return true
-	}
-	return false
-}
-
-func listHiddenComments( //nolint:funlen
-	ctx context.Context,
-	commenter Commenter, exp Expr,
-	getEnv func(string) string,
-	cmt comment.Comment,
-	paramExpr map[string]interface{},
-) ([]string, error) {
-	logE := logrus.WithFields(logrus.Fields{
-		"program": "github-comment",
-	})
-	if cmt.HideOldComment == "" {
-		logE.Debug("hide_old_comment isn't set")
-		return nil, nil
-	}
-	login, err := commenter.GetAuthenticatedUser(ctx)
-	if err != nil {
-		logE.WithError(err).Warn("get an authenticated user")
-	}
-
-	comments, err := commenter.List(ctx, comment.PullRequest{
-		Org:      cmt.Org,
-		Repo:     cmt.Repo,
-		PRNumber: cmt.PRNumber,
-	})
-	if err != nil {
-		return nil, err //nolint:wrapcheck
-	}
-	logE.WithFields(logrus.Fields{
-		"count":     len(comments),
-		"org":       cmt.Org,
-		"repo":      cmt.Repo,
-		"pr_number": cmt.PRNumber,
-	}).Debug("get comments")
-
-	nodeIDs := []string{}
-	prg, err := exp.Compile(cmt.HideOldComment)
-	if err != nil {
-		return nil, err //nolint:wrapcheck
-	}
-	for _, comment := range comments {
-		nodeID := comment.ID
-		// TODO remove these filters
-		if isExcludedComment(comment, login) {
-			logE.WithFields(logrus.Fields{
-				"node_id": nodeID,
-				"login":   login,
-			}).Debug("exclude a comment")
-			continue
-		}
-
-		metadata := map[string]interface{}{}
-		hasMeta := extractMetaFromComment(comment.Body, metadata)
-		param := map[string]interface{}{
-			"Comment": map[string]interface{}{
-				"Body": comment.Body,
-				// "CreatedAt": comment.CreatedAt,
-				"Meta":    metadata,
-				"HasMeta": hasMeta,
-			},
-			"Commit": map[string]interface{}{
-				"Org":      cmt.Org,
-				"Repo":     cmt.Repo,
-				"PRNumber": cmt.PRNumber,
-				"SHA1":     cmt.SHA1,
-			},
-			"Vars": cmt.Vars,
-			"PostedComment": map[string]interface{}{
-				"Body":        cmt.Body,
-				"TemplateKey": cmt.TemplateKey,
-			},
-			"Env": getEnv,
-		}
-		for k, v := range paramExpr {
-			param[k] = v
-		}
-
-		logE.WithFields(logrus.Fields{
-			"node_id":          nodeID,
-			"hide_old_comment": cmt.HideOldComment,
-			"param":            param,
-		}).Debug("judge whether an existing comment is hidden")
-		f, err := prg.Run(param)
-		if err != nil {
-			logE.WithError(err).WithFields(logrus.Fields{
-				"node_id": nodeID,
-			}).Error("judge whether an existing comment is hidden")
-			continue
-		}
-		if !f {
-			continue
-		}
-		nodeIDs = append(nodeIDs, nodeID)
-	}
-	return nodeIDs, nil
-}
-
-func isExcludedComment(cmt comment.IssueComment, login string) bool {
-	if !cmt.ViewerCanMinimize {
-		return true
-	}
-	if cmt.IsMinimized {
-		return true
-	}
-	// GitHub Actions's GITHUB_TOKEN secret doesn't have a permission to get an authenticated user.
-	// So if `login` is empty, we give up filtering comments by login.
-	if login != "" && cmt.Author.Login != login {
 		return true
 	}
 	return false

--- a/pkg/api/comment.go
+++ b/pkg/api/comment.go
@@ -212,6 +212,9 @@ func (ctrl *CommentController) complementMetaData(metadata map[string]interface{
 	if metadata == nil {
 		return
 	}
+	if ctrl.Platform == nil {
+		return
+	}
 	switch ctrl.Platform.CI() {
 	case "circleci":
 		metadata["job_name"] = ctrl.Getenv("CIRCLE_JOB")

--- a/pkg/api/comment.go
+++ b/pkg/api/comment.go
@@ -75,3 +75,12 @@ func (ctrl *CommentController) complementMetaData(metadata map[string]interface{
 		metadata["JobID"] = ctrl.Getenv("CODEBUILD_BUILD_ID")
 	}
 }
+
+func (ctrl *CommentController) getEmbeddedComment(metadata map[string]interface{}) (string, error) {
+	ctrl.complementMetaData(metadata)
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return "", fmt.Errorf("marshal an embedded metadata to JSON: %w", err)
+	}
+	return "\n<!-- github-comment: " + string(b) + " -->", nil
+}

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -195,7 +195,6 @@ func (ctrl *ExecController) getComment(
 	cmt := comment.Comment{}
 	tpl := cmtParams.Template
 	tplForTooLong := ""
-	hideOldComment := ""
 	if tpl == "" {
 		execConfig, f, err := ctrl.getExecConfig(execConfigs, cmtParams)
 		if err != nil {
@@ -209,7 +208,6 @@ func (ctrl *ExecController) getComment(
 		}
 		tpl = execConfig.Template
 		tplForTooLong = execConfig.TemplateForTooLong
-		hideOldComment = execConfig.HideOldComment
 	}
 
 	body, err := ctrl.Renderer.Render(tpl, templates, cmtParams)
@@ -227,7 +225,6 @@ func (ctrl *ExecController) getComment(
 		Body:           body,
 		BodyForTooLong: bodyForTooLong,
 		SHA1:           cmtParams.SHA1,
-		HideOldComment: hideOldComment,
 		Vars:           cmtParams.Vars,
 		TemplateKey:    cmtParams.TemplateKey,
 	}, true, nil

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -218,6 +218,25 @@ func (ctrl *ExecController) getComment(
 	if err != nil {
 		return cmt, false, fmt.Errorf("render a comment template_for_too_long: %w", err)
 	}
+
+	cmtCtrl := CommentController{
+		Commenter: ctrl.Commenter,
+		Expr:      ctrl.Expr,
+		Getenv:    ctrl.Getenv,
+		Platform:  ctrl.Platform,
+	}
+
+	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
+		"SHA1":        cmtParams.SHA1,
+		"TemplateKey": cmtParams.TemplateKey,
+	})
+	if err != nil {
+		return cmt, false, err
+	}
+
+	body += embeddedComment
+	bodyForTooLong += embeddedComment
+
 	return comment.Comment{
 		PRNumber:       cmtParams.PRNumber,
 		Org:            cmtParams.Org,

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -229,6 +229,7 @@ func (ctrl *ExecController) getComment(
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
 		"SHA1":        cmtParams.SHA1,
 		"TemplateKey": cmtParams.TemplateKey,
+		"Vars":        cmtParams.Vars,
 	})
 	if err != nil {
 		return cmt, false, err

--- a/pkg/api/hide.go
+++ b/pkg/api/hide.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+	"github.com/suzuki-shunsuke/github-comment/pkg/comment"
+	"github.com/suzuki-shunsuke/github-comment/pkg/config"
+	"github.com/suzuki-shunsuke/github-comment/pkg/option"
+)
+
+type HideController struct {
+	// Wd is a path to the working directory
+	Wd string
+	// Getenv returns the environment variable. os.Getenv
+	Getenv func(string) string
+	// HasStdin returns true if there is the standard input
+	// If thre is the standard input, it is treated as the comment template
+	HasStdin  func() bool
+	Stderr    io.Writer
+	Commenter Commenter
+	Platform  Platform
+	Config    config.Config
+	Expr      Expr
+}
+
+func (ctrl *HideController) Hide(ctx context.Context, opts option.HideOptions) error {
+	logE := logrus.WithFields(logrus.Fields{
+		"program": "github-comment",
+	})
+	cmt, err := ctrl.getCommentParams(opts)
+	if err != nil {
+		return err
+	}
+	nodeIDs, err := listHiddenComments(
+		ctx, ctrl.Commenter, ctrl.Expr, ctrl.Getenv, cmt, nil)
+	if err != nil {
+		return err
+	}
+	logE.WithFields(logrus.Fields{
+		"count":    len(nodeIDs),
+		"node_ids": nodeIDs,
+	}).Debug("comments which would be hidden")
+	hideComments(ctx, ctrl.Commenter, nodeIDs)
+	return nil
+}
+
+func (ctrl *HideController) getCommentParams(opts option.HideOptions) (comment.Comment, error) {
+	cmt := comment.Comment{}
+	if ctrl.Platform != nil {
+		if err := ctrl.Platform.ComplementHide(&opts); err != nil {
+			return cmt, fmt.Errorf("failed to complement opts with platform built in environment variables: %w", err)
+		}
+	}
+
+	cfg := ctrl.Config
+
+	if opts.Org == "" {
+		opts.Org = cfg.Base.Org
+	}
+	if opts.Repo == "" {
+		opts.Repo = cfg.Base.Repo
+	}
+
+	return comment.Comment{
+		PRNumber:       opts.PRNumber,
+		Org:            opts.Org,
+		Repo:           opts.Repo,
+		SHA1:           opts.SHA1,
+		HideOldComment: "Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1",
+	}, nil
+}

--- a/pkg/api/hide.go
+++ b/pkg/api/hide.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -64,12 +65,17 @@ func (ctrl *HideController) getCommentParams(opts option.HideOptions) (comment.C
 		opts.Repo = cfg.Base.Repo
 	}
 
+	hideCondition, ok := ctrl.Config.Hide[opts.HideKey]
+	if !ok {
+		return cmt, errors.New("invalid hide-key: " + opts.HideKey)
+	}
+
 	return comment.Comment{
 		PRNumber:       opts.PRNumber,
 		Org:            opts.Org,
 		Repo:           opts.Repo,
 		SHA1:           opts.SHA1,
-		HideOldComment: "Comment.HasMeta && Comment.Meta.SHA1 != Commit.SHA1",
+		HideOldComment: hideCondition,
 	}, nil
 }
 

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -116,7 +116,6 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 		}
 		opts.Template = tpl.Template
 		opts.TemplateForTooLong = tpl.TemplateForTooLong
-		opts.HideOldComment = tpl.HideOldComment
 	}
 
 	if cfg.Vars == nil {

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -156,23 +155,20 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 		return cmt, fmt.Errorf("render a template template_for_too_long for post: %w", err)
 	}
 
-	embeddedMetaData := map[string]interface{}{
-		"SHA1":        opts.SHA1,
-		"TemplateKey": opts.TemplateKey,
-	}
 	cmtCtrl := CommentController{
 		Commenter: ctrl.Commenter,
 		Expr:      ctrl.Expr,
 		Getenv:    ctrl.Getenv,
 		Platform:  ctrl.Platform,
 	}
-
-	cmtCtrl.complementMetaData(embeddedMetaData)
-	b, err := json.Marshal(embeddedMetaData)
+	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
+		"SHA1":        opts.SHA1,
+		"TemplateKey": opts.TemplateKey,
+	})
 	if err != nil {
-		return cmt, fmt.Errorf("marshal an embedded metadata to JSON: %w", err)
+		return cmt, err
 	}
-	embeddedComment := "\n<!-- github-comment: " + string(b) + " -->"
+
 	tpl += embeddedComment
 	tplForTooLong += embeddedComment
 

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -164,6 +164,7 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
 		"SHA1":        opts.SHA1,
 		"TemplateKey": opts.TemplateKey,
+		"Vars":        cfg.Vars,
 	})
 	if err != nil {
 		return cmt, err

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -77,6 +77,7 @@ type PostTemplateParams struct {
 type Platform interface {
 	ComplementPost(opts *option.PostOptions) error
 	ComplementExec(opts *option.ExecOptions) error
+	ComplementHide(opts *option.HideOptions) error
 	CI() string
 }
 

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -154,6 +155,26 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 	if err != nil {
 		return cmt, fmt.Errorf("render a template template_for_too_long for post: %w", err)
 	}
+
+	embeddedMetaData := map[string]interface{}{
+		"SHA1":        opts.SHA1,
+		"TemplateKey": opts.TemplateKey,
+	}
+	cmtCtrl := CommentController{
+		Commenter: ctrl.Commenter,
+		Expr:      ctrl.Expr,
+		Getenv:    ctrl.Getenv,
+		Platform:  ctrl.Platform,
+	}
+
+	cmtCtrl.complementMetaData(embeddedMetaData)
+	b, err := json.Marshal(embeddedMetaData)
+	if err != nil {
+		return cmt, fmt.Errorf("marshal an embedded metadata to JSON: %w", err)
+	}
+	embeddedComment := "\n<!-- github-comment: " + string(b) + " -->"
+	tpl += embeddedComment
+	tplForTooLong += embeddedComment
 
 	return comment.Comment{
 		PRNumber:       opts.PRNumber,

--- a/pkg/api/post_internal_test.go
+++ b/pkg/api/post_internal_test.go
@@ -45,7 +45,6 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "suzuki-shunsuke",
 				Repo:     "github-comment",
 				PRNumber: 1,
-				Body:     "hello",
 				Vars:     map[string]interface{}{},
 			},
 		},
@@ -74,7 +73,6 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "suzuki-shunsuke",
 				Repo:     "github-comment",
 				PRNumber: 1,
-				Body:     "foo",
 				Vars:     map[string]interface{}{},
 			},
 		},
@@ -113,7 +111,6 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:         "suzuki-shunsuke",
 				Repo:        "github-comment",
 				PRNumber:    1,
-				Body:        "hello",
 				TemplateKey: "default",
 				Vars:        map[string]interface{}{},
 			},
@@ -149,7 +146,6 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "suzuki-shunsuke",
 				Repo:     "github-comment",
 				PRNumber: 1,
-				Body:     "BAR suzuki-shunsuke github-comment 1",
 				Vars:     map[string]interface{}{},
 			},
 		},
@@ -182,7 +178,6 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "suzuki-shunsuke",
 				Repo:     "github-comment",
 				PRNumber: 1,
-				Body:     "hello",
 				Vars:     map[string]interface{}{},
 			},
 		},
@@ -197,6 +192,8 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				return
 			}
 			require.Nil(t, err)
+			cmt.Body = ""
+			cmt.BodyForTooLong = ""
 			require.Equal(t, d.exp, cmt)
 		})
 	}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -173,9 +173,19 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Name:  "config",
 						Usage: "configuration file path",
 					},
+					&cli.StringFlag{
+						Name:    "hide-key",
+						Aliases: []string{"k"},
+						Usage:   "hide condition key",
+						Value:   "default",
+					},
 					&cli.IntFlag{
 						Name:  "pr",
 						Usage: "GitHub pull request number",
+					},
+					&cli.StringFlag{
+						Name:  "sha1",
+						Usage: "commit sha1",
 					},
 					&cli.StringSliceFlag{
 						Name:  "var",

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -151,6 +151,53 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Usage:  "scaffold a configuration file if it doesn't exist",
 				Action: runner.initAction,
 			},
+			{
+				Name:   "hide",
+				Usage:  "hide issue or pull request comments",
+				Action: runner.hideAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "org",
+						Usage: "GitHub organization name",
+					},
+					&cli.StringFlag{
+						Name:  "repo",
+						Usage: "GitHub repository name",
+					},
+					&cli.StringFlag{
+						Name:    "token",
+						Usage:   "GitHub API token",
+						EnvVars: []string{"GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN"},
+					},
+					&cli.StringFlag{
+						Name:  "config",
+						Usage: "configuration file path",
+					},
+					&cli.IntFlag{
+						Name:  "pr",
+						Usage: "GitHub pull request number",
+					},
+					&cli.StringSliceFlag{
+						Name:  "var",
+						Usage: "template variable",
+					},
+					&cli.BoolFlag{
+						Name:  "dry-run",
+						Usage: "output a comment to standard error output instead of posting to GitHub",
+					},
+					&cli.BoolFlag{
+						Name:    "skip-no-token",
+						Aliases: []string{"n"},
+						Usage:   "works like dry-run if the GitHub Access Token isn't set",
+						EnvVars: []string{"GITHUB_COMMENT_SKIP_NO_TOKEN"},
+					},
+					&cli.BoolFlag{
+						Name:    "silent",
+						Aliases: []string{"s"},
+						Usage:   "suppress the output of dry-run and skip-no-token",
+					},
+				},
+			},
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/pkg/cmd/hide.go
+++ b/pkg/cmd/hide.go
@@ -27,6 +27,8 @@ func parseHideOptions(opts *option.HideOptions, c *cli.Context) error {
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
 	opts.LogLevel = c.String("log-level")
+	opts.HideKey = c.String("hide-key")
+	opts.SHA1 = c.String("sha1")
 	return nil
 }
 

--- a/pkg/cmd/hide.go
+++ b/pkg/cmd/hide.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/suzuki-shunsuke/github-comment/pkg/api"
+	"github.com/suzuki-shunsuke/github-comment/pkg/comment"
+	"github.com/suzuki-shunsuke/github-comment/pkg/config"
+	"github.com/suzuki-shunsuke/github-comment/pkg/expr"
+	"github.com/suzuki-shunsuke/github-comment/pkg/option"
+	"github.com/suzuki-shunsuke/github-comment/pkg/platform"
+	"github.com/urfave/cli/v2"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// parseHideOptions parses the command line arguments of the subcommand "hide".
+func parseHideOptions(opts *option.HideOptions, c *cli.Context) error {
+	opts.Org = c.String("org")
+	opts.Repo = c.String("repo")
+	opts.Token = c.String("token")
+	opts.ConfigPath = c.String("config")
+	opts.PRNumber = c.Int("pr")
+	opts.DryRun = c.Bool("dry-run")
+	opts.SkipNoToken = c.Bool("skip-no-token")
+	opts.Silent = c.Bool("silent")
+	opts.LogLevel = c.String("log-level")
+	return nil
+}
+
+func getHideCommenter(ctx context.Context, opts option.HideOptions) api.Commenter {
+	if opts.DryRun {
+		return comment.Mock{
+			Stderr: os.Stderr,
+			Silent: opts.Silent,
+		}
+	}
+	if opts.SkipNoToken && opts.Token == "" {
+		return comment.Mock{
+			Stderr: os.Stderr,
+			Silent: opts.Silent,
+		}
+	}
+
+	return comment.New(ctx, opts.Token)
+}
+
+// hideAction is an entrypoint of the subcommand "hide".
+func (runner *Runner) hideAction(c *cli.Context) error {
+	if a := os.Getenv("GITHUB_COMMENT_SKIP"); a != "" {
+		skipComment, err := strconv.ParseBool(a)
+		if err != nil {
+			return fmt.Errorf("parse the environment variable GITHUB_COMMENT_SKIP as a bool: %w", err)
+		}
+		if skipComment {
+			return nil
+		}
+	}
+	opts := option.HideOptions{}
+	if err := parseHideOptions(&opts, c); err != nil {
+		return err
+	}
+
+	setLogLevel(opts.LogLevel)
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get a current directory path: %w", err)
+	}
+
+	var pt api.Platform
+	if p, f := platform.Get(); f {
+		pt = &p
+	}
+
+	cfgReader := config.Reader{
+		ExistFile: existFile,
+	}
+
+	cfg, err := cfgReader.FindAndRead(opts.ConfigPath, wd)
+	if err != nil {
+		return fmt.Errorf("find and read a configuration file: %w", err)
+	}
+	opts.SkipNoToken = opts.SkipNoToken || cfg.SkipNoToken
+
+	ctrl := api.HideController{
+		Wd:     wd,
+		Getenv: os.Getenv,
+		HasStdin: func() bool {
+			return !terminal.IsTerminal(0)
+		},
+		Stderr:    runner.Stderr,
+		Commenter: getHideCommenter(c.Context, opts),
+		Platform:  pt,
+		Config:    cfg,
+		Expr:      &expr.Expr{},
+	}
+	return ctrl.Hide(c.Context, opts)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,6 @@ type Base struct {
 type PostConfig struct {
 	Template           string
 	TemplateForTooLong string `yaml:"template_for_too_long"`
-	HideOldComment     string `yaml:"hide_old_comment"`
 }
 
 func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -54,13 +53,6 @@ func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			pc.TemplateForTooLong = t
 		}
-		if tpl, ok := m["hide_old_comment"]; ok {
-			t, ok := tpl.(string)
-			if !ok {
-				return fmt.Errorf("invalid config. hide_old_comment should be string: %+v", tpl)
-			}
-			pc.HideOldComment = t
-		}
 		return nil
 	}
 	return fmt.Errorf("invalid config. post config should be string or map[string]intterface{}: %+v", val)
@@ -70,7 +62,6 @@ type ExecConfig struct {
 	When               string
 	Template           string
 	TemplateForTooLong string `yaml:"template_for_too_long"`
-	HideOldComment     string `yaml:"hide_old_comment"`
 	DontComment        bool   `yaml:"dont_comment"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Config struct {
-	Base        Base
-	Vars        map[string]interface{}
-	Templates   map[string]string
-	Post        map[string]PostConfig
-	Exec        map[string][]ExecConfig
-	SkipNoToken bool `yaml:"skip_no_token"`
-	Silent      bool
+	Base             Base
+	Vars             map[string]interface{}
+	Templates        map[string]string
+	Post             map[string]PostConfig
+	Exec             map[string][]ExecConfig
+	SkipNoToken      bool `yaml:"skip_no_token"`
+	Silent           bool
+	EmbeddedMetaData map[string]string `yaml:"embedded_meta_data"`
 }
 
 type Base struct {

--- a/pkg/option/hide.go
+++ b/pkg/option/hide.go
@@ -6,6 +6,7 @@ import (
 
 type HideOptions struct {
 	Options
+	HideKey       string
 	StdinTemplate bool
 }
 
@@ -13,8 +14,8 @@ func ValidateHide(opts HideOptions) error {
 	if err := validate(opts.Options); err != nil {
 		return err
 	}
-	if opts.Template == "" && opts.TemplateKey == "" {
-		return errors.New("template or template-key are required")
+	if opts.HideKey == "" {
+		return errors.New("hide-key is required")
 	}
 	return nil
 }

--- a/pkg/option/hide.go
+++ b/pkg/option/hide.go
@@ -1,0 +1,20 @@
+package option
+
+import (
+	"errors"
+)
+
+type HideOptions struct {
+	Options
+	StdinTemplate bool
+}
+
+func ValidateHide(opts HideOptions) error {
+	if err := validate(opts.Options); err != nil {
+		return err
+	}
+	if opts.Template == "" && opts.TemplateKey == "" {
+		return errors.New("template or template-key are required")
+	}
+	return nil
+}

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -38,6 +38,10 @@ func (pt *Platform) ComplementPost(opts *option.PostOptions) error {
 	return pt.complement(&opts.Options)
 }
 
+func (pt *Platform) ComplementHide(opts *option.HideOptions) error {
+	return pt.complement(&opts.Options)
+}
+
 func (pt *Platform) CI() string {
 	if pt.Platform == nil {
 		return ""


### PR DESCRIPTION
#205 

## Feature

* Add a command `hide`, which hides old comments

```
$ github-comment hide
```

### hide config

ex.

```yaml
---
hide:
  plan: 'Comment.HasMeta && (Comment.Meta.SHA1 != Commit.SHA1 || Comment.Meta.Vars.target == "foo")'
```

```
$ github-comment hide -k plan
```

## Breaking Changes

* a HTML comment is embedded to a comment
* remove the feature to hide comments in `post` and `exec` command

ex.

```
<!-- github-comment: {"SHA1":"79acc0778da6660712a65fd41a48b72cb7ad16c1","TemplateKey":"default","JobID":"xxx","JobName":"plan"} -->
```

## Embeded meta data

* SHA1
* TemplateKey
* Vars
* JobID (optional)
* JobName (optional)
* WorkflowName (optional)

These meta data can be referred in hide condition as `Comment.Meta`.

## Motivation

We think the current specification to hide comments has some problems.
It is inefficient to get comments and extract hidden comments from them several times.

So instead of hiding comments in `post` and `exec` command, we should call `hide` command in the begging of the CI.