### PR TITLE
feat: add hide condition option

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ $ github-comment hide -k hello
 
 If the template isn't specified, the template `default` is used.
 
+We can specify the condition with `-condition` option.
+
+```
+$ github-comment hide -condition 'Comment.Body contains "foo"'
+```
+
 ## Usage
 
 ```
@@ -344,6 +350,7 @@ OPTIONS:
    --repo value                GitHub repository name
    --token value               GitHub API token [$GITHUB_TOKEN, $GITHUB_ACCESS_TOKEN]
    --config value              configuration file path
+   --condition value           hide condition
    --hide-key value, -k value  hide condition key (default: "default")
    --pr value                  GitHub pull request number (default: 0)
    --sha1 value                commit sha1

--- a/pkg/api/hide.go
+++ b/pkg/api/hide.go
@@ -65,13 +65,17 @@ func (ctrl *HideController) getParamListHiddenComments(opts option.HideOptions) 
 		opts.Repo = cfg.Base.Repo
 	}
 
-	hideCondition, ok := ctrl.Config.Hide[opts.HideKey]
-	if !ok {
-		return param, errors.New("invalid hide-key: " + opts.HideKey)
-	}
-
 	if err := option.ValidateHide(opts); err != nil {
 		return param, fmt.Errorf("opts is invalid: %w", err)
+	}
+
+	hideCondition := opts.Condition
+	if hideCondition == "" {
+		a, ok := ctrl.Config.Hide[opts.HideKey]
+		if !ok {
+			return param, errors.New("invalid hide-key: " + opts.HideKey)
+		}
+		hideCondition = a
 	}
 
 	return ParamListHiddenComments{

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -174,6 +174,10 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Usage: "configuration file path",
 					},
 					&cli.StringFlag{
+						Name:  "condition",
+						Usage: "hide condition",
+					},
+					&cli.StringFlag{
 						Name:    "hide-key",
 						Aliases: []string{"k"},
 						Usage:   "hide condition key",

--- a/pkg/cmd/hide.go
+++ b/pkg/cmd/hide.go
@@ -28,6 +28,7 @@ func parseHideOptions(opts *option.HideOptions, c *cli.Context) error {
 	opts.Silent = c.Bool("silent")
 	opts.LogLevel = c.String("log-level")
 	opts.HideKey = c.String("hide-key")
+	opts.Condition = c.String("condition")
 	opts.SHA1 = c.String("sha1")
 	return nil
 }

--- a/pkg/option/hide.go
+++ b/pkg/option/hide.go
@@ -7,6 +7,7 @@ import (
 type HideOptions struct {
 	Options
 	HideKey       string
+	Condition     string
 	StdinTemplate bool
 }
 
@@ -14,8 +15,8 @@ func ValidateHide(opts HideOptions) error {
 	if opts.PRNumber == 0 {
 		return errors.New("pull request or issue number is required")
 	}
-	if opts.HideKey == "" {
-		return errors.New("hide-key is required")
+	if opts.HideKey == "" || opts.Condition == "" {
+		return errors.New("hide-key or condition are required")
 	}
 	return validate(opts.Options)
 }


### PR DESCRIPTION
Support to specify the condition with `-condition` option.

```
$ github-comment hide -condition 'Comment.Body contains "foo"'
```