### PR TITLE
feat: add the -var-file option to the post command

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -89,7 +89,7 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 					},
 				},
 			},
-			{ //nolint:dupl
+			{
 				Name:   "exec",
 				Usage:  "execute a command and post the result as a comment",
 				Action: runner.execAction,
@@ -133,6 +133,10 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Name:  "var",
 						Usage: "template variable",
 					},
+					&cli.StringSliceFlag{
+						Name:  "var-file",
+						Usage: "template variable name and file path",
+					},
 					&cli.BoolFlag{
 						Name:  "dry-run",
 						Usage: "output a comment to standard error output instead of posting to GitHub",
@@ -155,7 +159,7 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Usage:  "scaffold a configuration file if it doesn't exist",
 				Action: runner.initAction,
 			},
-			{ //nolint:dupl
+			{
 				Name:   "hide",
 				Usage:  "hide issue or pull request comments",
 				Action: runner.hideAction,

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -64,6 +64,10 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Name:  "var",
 						Usage: "template variable",
 					},
+					&cli.StringSliceFlag{
+						Name:  "var-file",
+						Usage: "template variable name and file path",
+					},
 					&cli.BoolFlag{
 						Name:  "dry-run",
 						Usage: "output a comment to standard error output instead of posting to GitHub",
@@ -85,7 +89,7 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 					},
 				},
 			},
-			{
+			{ //nolint:dupl
 				Name:   "exec",
 				Usage:  "execute a command and post the result as a comment",
 				Action: runner.execAction,
@@ -151,7 +155,7 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Usage:  "scaffold a configuration file if it doesn't exist",
 				Action: runner.initAction,
 			},
-			{
+			{ //nolint:dupl
 				Name:   "hide",
 				Usage:  "hide issue or pull request comments",
 				Action: runner.hideAction,

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -31,11 +31,20 @@ func parseExecOptions(opts *option.ExecOptions, c *cli.Context) error {
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
 	opts.LogLevel = c.String("log-level")
+
 	vars, err := parseVarsFlag(c.StringSlice("var"))
 	if err != nil {
 		return err
 	}
+	varFiles, err := parseVarFilesFlag(c.StringSlice("var-file"))
+	if err != nil {
+		return err
+	}
+	for k, v := range varFiles {
+		vars[k] = v
+	}
 	opts.Vars = vars
+
 	return nil
 }
 

--- a/pkg/comment/comment.go
+++ b/pkg/comment/comment.go
@@ -81,6 +81,9 @@ func (commenter Commenter) create(ctx context.Context, cmt Comment, tooLong bool
 
 func (commenter Commenter) Create(ctx context.Context, cmt Comment) error {
 	err := commenter.create(ctx, cmt, false)
+	if err == nil {
+		return nil
+	}
 	if cmt.BodyForTooLong == "" {
 		return err
 	}


### PR DESCRIPTION
Close #277

```
$ github-comment post -var-file content:foo.txt
```

```
$ github-comment exec -var-file content:foo.txt -- echo hello
```