### PR TITLE
feat: add embeded_var_names to post and exec config

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ The following meta data is injected.
 * Vars
 * SHA1
 
+From github-comment v4, only variables specified by `embedded_var_names` are embedded into the comment.
+
 In `hide` command, github-comment does the following things.
 
 1. gets the list of pull request (issue) comments

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -189,12 +189,11 @@ func (ctrl *ExecController) getExecConfig(
 
 // getComment returns Comment.
 // If the second returned value is false, no comment is posted.
-func (ctrl *ExecController) getComment(
-	execConfigs []config.ExecConfig, cmtParams ExecCommentParams, templates map[string]string,
-) (comment.Comment, bool, error) {
+func (ctrl *ExecController) getComment(execConfigs []config.ExecConfig, cmtParams ExecCommentParams, templates map[string]string) (comment.Comment, bool, error) { //nolint:funlen
 	cmt := comment.Comment{}
 	tpl := cmtParams.Template
 	tplForTooLong := ""
+	var embeddedVarNames []string
 	if tpl == "" {
 		execConfig, f, err := ctrl.getExecConfig(execConfigs, cmtParams)
 		if err != nil {
@@ -208,6 +207,7 @@ func (ctrl *ExecController) getComment(
 		}
 		tpl = execConfig.Template
 		tplForTooLong = execConfig.TemplateForTooLong
+		embeddedVarNames = execConfig.EmbeddedVarNames
 	}
 
 	body, err := ctrl.Renderer.Render(tpl, templates, cmtParams)
@@ -226,10 +226,15 @@ func (ctrl *ExecController) getComment(
 		Platform:  ctrl.Platform,
 	}
 
+	embeddedMetadata := make(map[string]interface{}, len(embeddedVarNames))
+	for _, name := range embeddedVarNames {
+		embeddedMetadata[name] = cmtParams.Vars[name]
+	}
+
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
 		"SHA1":        cmtParams.SHA1,
 		"TemplateKey": cmtParams.TemplateKey,
-		"Vars":        cmtParams.Vars,
+		"Vars":        embeddedMetadata,
 	})
 	if err != nil {
 		return cmt, false, err

--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -228,7 +228,9 @@ func (ctrl *ExecController) getComment(execConfigs []config.ExecConfig, cmtParam
 
 	embeddedMetadata := make(map[string]interface{}, len(embeddedVarNames))
 	for _, name := range embeddedVarNames {
-		embeddedMetadata[name] = cmtParams.Vars[name]
+		if v, ok := cmtParams.Vars[name]; ok {
+			embeddedMetadata[name] = v
+		}
 	}
 
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -164,7 +164,9 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 	}
 	embeddedMetadata := make(map[string]interface{}, len(opts.EmbeddedVarNames))
 	for _, name := range opts.EmbeddedVarNames {
-		embeddedMetadata[name] = cfg.Vars[name]
+		if v, ok := cfg.Vars[name]; ok {
+			embeddedMetadata[name] = v
+		}
 	}
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
 		"SHA1":        opts.SHA1,

--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -115,6 +115,7 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 		}
 		opts.Template = tpl.Template
 		opts.TemplateForTooLong = tpl.TemplateForTooLong
+		opts.EmbeddedVarNames = tpl.EmbeddedVarNames
 	}
 
 	if cfg.Vars == nil {
@@ -161,10 +162,14 @@ func (ctrl *PostController) getCommentParams(opts option.PostOptions) (comment.C
 		Getenv:    ctrl.Getenv,
 		Platform:  ctrl.Platform,
 	}
+	embeddedMetadata := make(map[string]interface{}, len(opts.EmbeddedVarNames))
+	for _, name := range opts.EmbeddedVarNames {
+		embeddedMetadata[name] = cfg.Vars[name]
+	}
 	embeddedComment, err := cmtCtrl.getEmbeddedComment(map[string]interface{}{
 		"SHA1":        opts.SHA1,
 		"TemplateKey": opts.TemplateKey,
-		"Vars":        cfg.Vars,
+		"Vars":        embeddedMetadata,
 	})
 	if err != nil {
 		return cmt, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,8 +78,9 @@ func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error { /
 type ExecConfig struct {
 	When               string
 	Template           string
-	TemplateForTooLong string `yaml:"template_for_too_long"`
-	DontComment        bool   `yaml:"dont_comment"`
+	TemplateForTooLong string   `yaml:"template_for_too_long"`
+	DontComment        bool     `yaml:"dont_comment"`
+	EmbeddedVarNames   []string `yaml:"embedded_var_names"`
 }
 
 type ExistFile func(string) bool

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,10 +27,11 @@ type Base struct {
 
 type PostConfig struct {
 	Template           string
-	TemplateForTooLong string `yaml:"template_for_too_long"`
+	TemplateForTooLong string
+	EmbeddedVarNames   []string
 }
 
-func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error { //nolint:cyclop
 	var val interface{}
 	if err := unmarshal(&val); err != nil {
 		return err
@@ -53,6 +54,21 @@ func (pc *PostConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				return fmt.Errorf("invalid config. template_for_too_long should be string: %+v", tpl)
 			}
 			pc.TemplateForTooLong = t
+		}
+		if tpl, ok := m["embedded_var_names"]; ok {
+			t, ok := tpl.([]interface{})
+			if !ok {
+				return fmt.Errorf("invalid config. embedded_var_names should be []interface{}: %+v", tpl)
+			}
+			names := make([]string, len(t))
+			for i, name := range t {
+				s, ok := name.(string)
+				if !ok {
+					return fmt.Errorf("invalid config. embedded_var_names[%d] should be string: %+v", i, name)
+				}
+				names[i] = s
+			}
+			pc.EmbeddedVarNames = names
 		}
 		return nil
 	}

--- a/pkg/option/post.go
+++ b/pkg/option/post.go
@@ -17,6 +17,7 @@ type Options struct {
 	HideOldComment     string
 	LogLevel           string
 	Vars               map[string]string
+	EmbeddedVarNames   []string
 	DryRun             bool
 	SkipNoToken        bool
 	Silent             bool


### PR DESCRIPTION
BREAKING CHANGE: no variable becomes embedded in comment by default

github-comment embedds the metadata into the comment to hide the comment by the metadata.
With github-comment v3, all variables are embedded into the comment, but sometimes this behaviour is undesirable.
With github-comment v4, only variables specified by `embedded_var_names` are embedded into the comment.

```yaml
post:
  hello:
    template: "Hello {{.Vars.name}}"
    embedded_var_names:
      - name
exec:
  hello:
    - when: true
      template: "Hello {{.Vars.name}}"
      embedded_var_names:
        - name
```
