### PR TITLE
feat: support passing some command line arguments via environment variables

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -36,12 +36,14 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Action: runner.postAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "org",
-						Usage: "GitHub organization name",
+						Name:    "org",
+						Usage:   "GitHub organization name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_ORG", "GHCMT_REPO_ORG"},
 					},
 					&cli.StringFlag{
-						Name:  "repo",
-						Usage: "GitHub repository name",
+						Name:    "repo",
+						Usage:   "GitHub repository name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_NAME", "GHCMT_REPO_NAME"},
 					},
 					&cli.StringFlag{
 						Name:    "token",
@@ -49,8 +51,9 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						EnvVars: []string{"GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN"},
 					},
 					&cli.StringFlag{
-						Name:  "sha1",
-						Usage: "commit sha1",
+						Name:    "sha1",
+						Usage:   "commit sha1",
+						EnvVars: []string{"GITHUB_COMMENT_SHA1", "GHCMT_SHA1"},
 					},
 					&cli.StringFlag{
 						Name:  "template",
@@ -63,12 +66,14 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Value:   "default",
 					},
 					&cli.StringFlag{
-						Name:  "config",
-						Usage: "configuration file path",
+						Name:    "config",
+						Usage:   "configuration file path",
+						EnvVars: []string{"GITHUB_COMMENT_CONFIG", "GHCMT_CONFIG"},
 					},
 					&cli.IntFlag{
-						Name:  "pr",
-						Usage: "GitHub pull request number",
+						Name:    "pr",
+						Usage:   "GitHub pull request number",
+						EnvVars: []string{"GITHUB_COMMENT_PR_NUMBER", "GHCMT_PR_NUMBER"},
 					},
 					&cli.StringSliceFlag{
 						Name:  "var",
@@ -110,12 +115,14 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Action: runner.execAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "org",
-						Usage: "GitHub organization name",
+						Name:    "org",
+						Usage:   "GitHub organization name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_ORG", "GHCMT_REPO_ORG"},
 					},
 					&cli.StringFlag{
-						Name:  "repo",
-						Usage: "GitHub repository name",
+						Name:    "repo",
+						Usage:   "GitHub repository name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_NAME", "GHCMT_REPO_NAME"},
 					},
 					&cli.StringFlag{
 						Name:    "token",
@@ -123,8 +130,9 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						EnvVars: []string{"GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN"},
 					},
 					&cli.StringFlag{
-						Name:  "sha1",
-						Usage: "commit sha1",
+						Name:    "sha1",
+						Usage:   "commit sha1",
+						EnvVars: []string{"GITHUB_COMMENT_SHA1", "GHCMT_SHA1"},
 					},
 					&cli.StringFlag{
 						Name:  "template",
@@ -137,12 +145,14 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Value:   "default",
 					},
 					&cli.StringFlag{
-						Name:  "config",
-						Usage: "configuration file path",
+						Name:    "config",
+						Usage:   "configuration file path",
+						EnvVars: []string{"GITHUB_COMMENT_CONFIG", "GHCMT_CONFIG"},
 					},
 					&cli.IntFlag{
-						Name:  "pr",
-						Usage: "GitHub pull request number",
+						Name:    "pr",
+						Usage:   "GitHub pull request number",
+						EnvVars: []string{"GITHUB_COMMENT_PR_NUMBER", "GHCMT_PR_NUMBER"},
 					},
 					&cli.StringSliceFlag{
 						Name:  "var",
@@ -180,12 +190,14 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 				Action: runner.hideAction,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "org",
-						Usage: "GitHub organization name",
+						Name:    "org",
+						Usage:   "GitHub organization name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_ORG", "GHCMT_REPO_ORG"},
 					},
 					&cli.StringFlag{
-						Name:  "repo",
-						Usage: "GitHub repository name",
+						Name:    "repo",
+						Usage:   "GitHub repository name",
+						EnvVars: []string{"GITHUB_COMMENT_REPO_NAME", "GHCMT_REPO_NAME"},
 					},
 					&cli.StringFlag{
 						Name:    "token",
@@ -193,8 +205,9 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						EnvVars: []string{"GITHUB_TOKEN", "GITHUB_ACCESS_TOKEN"},
 					},
 					&cli.StringFlag{
-						Name:  "config",
-						Usage: "configuration file path",
+						Name:    "config",
+						Usage:   "configuration file path",
+						EnvVars: []string{"GITHUB_COMMENT_CONFIG", "GHCMT_CONFIG"},
 					},
 					&cli.StringFlag{
 						Name:  "condition",
@@ -207,8 +220,9 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "pr",
-						Usage: "GitHub pull request number",
+						Name:    "pr",
+						Usage:   "GitHub pull request number",
+						EnvVars: []string{"GITHUB_COMMENT_PR_NUMBER", "GHCMT_PR_NUMBER"},
 					},
 					&cli.StringFlag{
 						Name:  "sha1",


### PR DESCRIPTION
- `-org`: `GITHUB_COMMENT_REPO_ORG`, `GHCMT_REPO_ORG`
- `-repo`: `GITHUB_COMMENT_REPO_NAME`, `GHCMT_REPO_NAME`
- `-sha1`: `GITHUB_COMMENT_SHA1`, `GHCMT_SHA1`
- `-config`: `GITHUB_COMMENT_CONFIG`, `GHCMT_CONFIG`
- `-pr`: `GITHUB_COMMENT_PR_NUMBER`, `GHCMT_PR_NUMBER`