### PR TITLE
chore: add warning comment for body too long

### DIFF
--- a/pkg/github/comment.go
+++ b/pkg/github/comment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v49/github"
+	"github.com/sirupsen/logrus"
 )
 
 type Comment struct {
@@ -69,8 +70,14 @@ func (client *Client) sendCommitComment(ctx context.Context, cmt *Comment, body 
 }
 
 func (client *Client) createComment(ctx context.Context, cmt *Comment, tooLong bool) error {
+	logE := logrus.WithFields(logrus.Fields{
+		"program": "github-comment",
+	})
 	body := cmt.Body
 	if tooLong {
+		logE.WithFields(logrus.Fields{
+			"body_length": len(body),
+		}).Warn("body is too long so it is replaced with `BodyForTooLong`")
 		body = cmt.BodyForTooLong
 	}
 	if cmt.PRNumber != 0 {


### PR DESCRIPTION
## What
Based on the following discussion, I added a waring log when github-comment uses `BodyForTooLong`.
- https://github.com/suzuki-shunsuke/github-comment/discussions/986

## Why

If `BodyForTooLong` is unset, the body of comment will be empty without any logs.
By adding the log, developers can debug their comment easliy.