### PR TITLE
fix: added check of exists args in `github-comment exec` command

### DIFF
--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -67,6 +67,10 @@ func (c *ExecController) Exec(ctx context.Context, opts *option.ExecOptions) err
 		}
 	}
 
+	if len(opts.Args) == 0 {
+		return errors.New("command is required")
+	}
+
 	result, execErr := c.Executor.Run(ctx, &execute.Params{
 		Cmd:   opts.Args[0],
 		Args:  opts.Args[1:],


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue: https://github.com/suzuki-shunsuke/github-comment/issues/1581
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

### Summary
A panic occurred when I executed `github-comment exec` without args.

```bash
$ github-comment exec --
panic: runtime error: slice bounds out of range [1:0]

goroutine 1 [running]:
github.com/suzuki-shunsuke/github-comment/v6/pkg/api.(*ExecController).Exec(0x140001cf358, {0x1007b3138, 0x14000139300}, 0x1400011a7e0)
        /home/runner/work/github-comment/github-comment/pkg/api/exec.go:72 +0xb94
github.com/suzuki-shunsuke/github-comment/v6/pkg/cmd.(*Runner).execAction(0x14000139340, 0x14000139600)
        /home/runner/work/github-comment/github-comment/pkg/cmd/exec.go:123 +0x5bc
github.com/urfave/cli/v2.(*Command).Run(0x140001a0420, 0x14000139600, {0x14000155620, 0x2, 0x2})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/command.go:276 +0x600
github.com/urfave/cli/v2.(*Command).Run(0x140001a09a0, 0x14000139480, {0x140001180f0, 0x3, 0x3})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/command.go:269 +0x83c
github.com/urfave/cli/v2.(*App).RunContext(0x14000222200, {0x1007b3138, 0x14000139300}, {0x140001180f0, 0x3, 0x3})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.27.4/app.go:333 +0x51c
github.com/suzuki-shunsuke/github-comment/v6/pkg/cmd.(*Runner).Run(0x14000139340, {0x1007b3138, 0x14000139300}, {0x140001180f0, 0x3, 0x3})
        /home/runner/work/github-comment/github-comment/pkg/cmd/app.go:269 +0x1ccc
main.core()
        /home/runner/work/github-comment/github-comment/cmd/github-comment/main.go:39 +0x1f0
main.main()
        /home/runner/work/github-comment/github-comment/cmd/github-comment/main.go:20 +0x1c
```

https://github.com/suzuki-shunsuke/github-comment/blob/9b6821c0d1fbac8ca0d9f6a0e8a47749f6a013cf/pkg/api/exec.go#L72
