### PR TITLE
feat: add update-condition for github-comment exec

### DIFF
--- a/pkg/api/exec.go
+++ b/pkg/api/exec.go
@@ -112,20 +112,21 @@ func (c *ExecController) Exec(ctx context.Context, opts *option.ExecOptions) err
 		CombinedOutput: result.CombinedOutput,
 	})
 	if err := c.post(ctx, execConfigs, &ExecCommentParams{
-		ExitCode:       result.ExitCode,
-		Command:        result.Cmd,
-		JoinCommand:    joinCommand,
-		Stdout:         result.Stdout,
-		Stderr:         result.Stderr,
-		CombinedOutput: result.CombinedOutput,
-		PRNumber:       opts.PRNumber,
-		Org:            opts.Org,
-		Repo:           opts.Repo,
-		SHA1:           opts.SHA1,
-		TemplateKey:    opts.TemplateKey,
-		Template:       opts.Template,
-		Vars:           cfg.Vars,
-		Outputs:        opts.Outputs,
+		ExitCode:        result.ExitCode,
+		Command:         result.Cmd,
+		JoinCommand:     joinCommand,
+		Stdout:          result.Stdout,
+		Stderr:          result.Stderr,
+		CombinedOutput:  result.CombinedOutput,
+		PRNumber:        opts.PRNumber,
+		Org:             opts.Org,
+		Repo:            opts.Repo,
+		SHA1:            opts.SHA1,
+		TemplateKey:     opts.TemplateKey,
+		Template:        opts.Template,
+		Vars:            cfg.Vars,
+		Outputs:         opts.Outputs,
+		UpdateCondition: opts.UpdateCondition,
 	}, templates); err != nil {
 		if !opts.Silent {
 			fmt.Fprintf(c.Stderr, "github-comment error: %+v\n", err)
@@ -151,11 +152,12 @@ type ExecCommentParams struct {
 	// Repo is the GitHub Repository name
 	Repo string
 	// SHA1 is the commit SHA1
-	SHA1        string
-	TemplateKey string
-	Template    string
-	Vars        map[string]interface{}
-	Outputs     []*option.Output
+	SHA1            string
+	TemplateKey     string
+	Template        string
+	Vars            map[string]interface{}
+	Outputs         []*option.Output
+	UpdateCondition string
 }
 
 type Executor interface {
@@ -230,6 +232,9 @@ func (c *ExecController) getComment(execConfigs []*config.ExecConfig, cmtParams 
 		tpl = execConfig.Template
 		tplForTooLong = execConfig.TemplateForTooLong
 		embeddedVarNames = execConfig.EmbeddedVarNames
+		if execConfig.UpdateCondition != "" {
+			cmtParams.UpdateCondition = execConfig.UpdateCondition
+		}
 	}
 
 	body, err := c.Renderer.Render(tpl, templates, cmtParams)
@@ -290,6 +295,11 @@ func (c *ExecController) post(
 	if !f {
 		return nil
 	}
+	if cmtParams.UpdateCondition != "" && cmtParams.PRNumber != 0 {
+		if err := c.setUpdatedCommentID(ctx, cmt, cmtParams.UpdateCondition); err != nil {
+			return err
+		}
+	}
 	logrus.WithFields(logrus.Fields{
 		"org":       cmt.Org,
 		"repo":      cmt.Repo,
@@ -342,6 +352,78 @@ func (c *ExecController) handleOutput(ctx context.Context, cmt *github.Comment, 
 	defer file.Close()
 	if _, err := file.WriteString(cmt.Body); err != nil {
 		return fmt.Errorf("write a comment to a file: %w", err)
+	}
+	return nil
+}
+
+func (c *ExecController) setUpdatedCommentID(ctx context.Context, cmt *github.Comment, updateCondition string) error { //nolint:funlen
+	prg, err := c.Expr.Compile(updateCondition)
+	if err != nil {
+		return err //nolint:wrapcheck
+	}
+
+	login, err := c.GitHub.GetAuthenticatedUser(ctx)
+	if err != nil {
+		logrus.WithError(err).Warn("get an authenticated user")
+	}
+
+	comments, err := c.GitHub.ListComments(ctx, &github.PullRequest{
+		Org:      cmt.Org,
+		Repo:     cmt.Repo,
+		PRNumber: cmt.PRNumber,
+	})
+	if err != nil {
+		return fmt.Errorf("list issue or pull request comments: %w", err)
+	}
+	logrus.WithFields(logrus.Fields{
+		"org":       cmt.Org,
+		"repo":      cmt.Repo,
+		"pr_number": cmt.PRNumber,
+	}).Debug("get comments")
+
+	for _, comnt := range comments {
+		if comnt.IsMinimized {
+			// ignore minimized comments
+			continue
+		}
+		if login != "" && comnt.Author.Login != login {
+			// ignore other users' comments
+			continue
+		}
+
+		metadata := map[string]interface{}{}
+		hasMeta := extractMetaFromComment(comnt.Body, &metadata)
+		paramMap := map[string]interface{}{
+			"Comment": map[string]interface{}{
+				"Body":    comnt.Body,
+				"Meta":    metadata,
+				"HasMeta": hasMeta,
+			},
+			"Commit": map[string]interface{}{
+				"Org":      cmt.Org,
+				"Repo":     cmt.Repo,
+				"PRNumber": cmt.PRNumber,
+				"SHA1":     cmt.SHA1,
+			},
+			"Vars": cmt.Vars,
+		}
+
+		logrus.WithFields(logrus.Fields{
+			"node_id":   comnt.ID,
+			"condition": updateCondition,
+			"param":     paramMap,
+		}).Debug("judge whether an existing comment is ready for editing")
+		f, err := prg.Run(paramMap)
+		if err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"node_id": comnt.ID,
+			}).Error("judge whether an existing comment is hidden")
+			continue
+		}
+		if !f {
+			continue
+		}
+		cmt.CommentID = comnt.DatabaseID
 	}
 	return nil
 }

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -181,6 +181,11 @@ func (r *Runner) Run(ctx context.Context, args []string) error { //nolint:funlen
 						Aliases: []string{"s"},
 						Usage:   "suppress the output of dry-run and skip-no-token",
 					},
+					&cli.StringFlag{
+						Name:    "update-condition",
+						Aliases: []string{"u"},
+						Usage:   "update the comment that matches with the condition",
+					},
 				},
 			},
 			{

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -32,6 +32,7 @@ func parseExecOptions(opts *option.ExecOptions, c *cli.Context) error {
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
 	opts.LogLevel = c.String("log-level")
+	opts.UpdateCondition = c.String("update-condition")
 
 	outputs := c.StringSlice("out")
 	outs := make([]*option.Output, len(outputs))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,6 +109,10 @@ type ExecConfig struct {
 	TemplateForTooLong string   `json:"template_for_too_long,omitempty" yaml:"template_for_too_long"`
 	DontComment        bool     `json:"dont_comment,omitempty" yaml:"dont_comment" jsonschema:"description=Don't post a comment"`
 	EmbeddedVarNames   []string `json:"embedded_var_names,omitempty" yaml:"embedded_var_names" jsonschema:"description=Embedded variable names"`
+	// UpdateCondition Update the comment that matches with the condition.
+	// If multiple comments match, the latest comment is updated.
+	// If no comment matches, a new comment is created.
+	UpdateCondition string `json:"update,omitempty" yaml:"update" jsonschema:"description=Update comments that matches with the condition"`
 }
 
 func (ec ExecConfig) JSONSchemaExtend(schema *jsonschema.Schema) {

--- a/pkg/option/exec.go
+++ b/pkg/option/exec.go
@@ -6,9 +6,10 @@ import (
 
 type ExecOptions struct {
 	Options
-	Args        []string
-	SkipComment bool
-	Outputs     []*Output
+	Args            []string
+	SkipComment     bool
+	Outputs         []*Output
+	UpdateCondition string
 }
 
 type Output struct {


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [Write a GitHub Issue before creating a Pull Request](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md#create-an-issue-before-creating-a-pull-request)
  - Link to the issue:
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request

<!-- Please write the description here -->

I have added `--update-conditon` to exec sub-command so that existing comments can be overwritten. post implementation as a reference (PR: https://github.com/suzuki-shunsuke/github-comment/issues/473)

related:
- https://github.com/suzuki-shunsuke/github-comment/discussions/972
- https://github.com/suzuki-shunsuke/github-comment/issues/473
