### PR TITLE
chore: fix Homebrew tap to remove the quarantine bit from the binary on a post install hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,10 +65,11 @@ homebrew_casks:
       CLI to create and hide GitHub comments
     license: MIT
 
-    # Setting this will prevent goreleaser to actually try to commit the updated
-    # formula - instead, the formula file will be stored on the dist folder only,
-    # leaving the responsibility of publishing it to the user.
-    # If set to auto, the release will not be uploaded to the homebrew tap
-    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
-    # Default is false.
     skip_upload: true
+
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/github-comment"]
+          end


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/ghalint/issues/966