### PR TITLE
fix(deps): override serialize-javascript to ^7.0.5

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15312,15 +15312,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16306,12 +16297,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/website/package.json
+++ b/website/package.json
@@ -22,6 +22,9 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## Summary

- Adds an npm `overrides` entry to force `serialize-javascript@^7.0.5` in `website/`, picking up the upstream patches for RCE and DoS.
- Docusaurus pins `copy-webpack-plugin@^11` / `css-minimizer-webpack-plugin@^5`, both of which depend on `serialize-javascript@^6.x`. There is no 6.x backport (patches only exist in 7.0.3 / 7.0.5), so the override is required.

Resolves Dependabot alerts:
- #41 — RCE via `RegExp.flags` and `Date.prototype.toISOString()` (HIGH, GHSA-76p7-773f-r4q5)
- #57 — CPU exhaustion DoS via crafted array-like objects (medium)

## Test plan

- [x] `npm install` in `website/` resolves `serialize-javascript@7.0.5`
- [x] `npm run build` in `website/` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)