### PR TITLE
ci(security): use takumi guard for the website npm install

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,7 +5,9 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: suzuki-shunsuke/go-autofix-action@ba716cebb7767055bdde0e62bb91d715bde39ab2 # v0.1.12
@@ -17,8 +19,22 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+          set-registry: "false" # The registry is committed in website/.npmrc
+      - name: Add the registry auth token to website/.npmrc
+        # setup-takumi-guard-npm writes the token to ./.npmrc, but npm ci runs in
+        # website/ and npm does not read parent directories' .npmrc.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> website/.npmrc
+            rm .npmrc
+          fi
       - run: npm ci
         working-directory: website
+      - name: Restore website/.npmrc to avoid committing the registry auth token
+        run: git checkout -- website/.npmrc
       - run: bash scripts/generate-usage.sh
         working-directory: website
 

--- a/.github/workflows/deploy_doc.yaml
+++ b/.github/workflows/deploy_doc.yaml
@@ -12,6 +12,9 @@ permissions: {}
 jobs:
   deploy-doc:
     uses: ./.github/workflows/workflow_call_deploy_doc.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
+      id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,10 +5,13 @@ on: pull_request
 jobs:
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: write
       issues: write
+      id-token: write
   status-check:
     runs-on: ubuntu-24.04
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))

--- a/.github/workflows/workflow_call_deploy_doc.yaml
+++ b/.github/workflows/workflow_call_deploy_doc.yaml
@@ -1,6 +1,10 @@
 ---
 name: Deploy GitHub Pages (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   deploy-doc:
@@ -9,7 +13,22 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write # Required for OIDC
     steps:
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+          set-registry: "false" # The registry is committed in website/.npmrc
+      - name: Move the registry auth token to the user npmrc
+        # release-doc-action runs its own actions/checkout (clean) and `npm ci`
+        # in website/, which would wipe a workspace .npmrc. Put the token in
+        # ~/.npmrc so it survives the checkout, while the registry comes from the
+        # committed website/.npmrc.
+        run: |
+          if [ -f .npmrc ]; then
+            cat .npmrc >> "$HOME/.npmrc"
+            rm .npmrc
+          fi
       - uses: suzuki-shunsuke/release-doc-action@a9e1ea0c4ca8c62906ca2a7fd3fa33325ee43ec9 # v0.1.0
         with:
           issue_number: 1892

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,7 +1,11 @@
 ---
 name: test (workflow_call)
 permissions: {}
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
     uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
@@ -33,6 +37,9 @@ jobs:
 
   test_deploy_doc:
     uses: ./.github/workflows/workflow_call_deploy_doc.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       issues: write
+      id-token: write

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://shisho.dev/docs/r/202604-takumi-guard-rate-limit/#getting-started-with-organization-usage) to authenticate the **website's** npm installs against the private registry (`npm.flatt.tech`), mirroring csm-actions/securefix-action#668 (already applied to label-action, update-branch-action, lock-action, tfaction, and tfcmt — this follows the same subdir handling as tfcmt).

The website lives in a subdirectory, so the standard single-repo pattern can't be applied verbatim. Two constraints drive the design:

1. **npm does not read parent directories' `.npmrc`** — so the registry/token must be visible to npm *in `website/`*.
2. **`setup-takumi-guard-npm` writes the token to the current directory's `.npmrc`**, and `working-directory` can't be set on a `uses:` step.

## Changes

- **`website/.npmrc`** (new) — `registry=https://npm.flatt.tech/`. Routes the website's installs through Takumi Guard.
- **`autofix.yaml`** — run `setup-takumi-guard-npm` with `set-registry: false` (registry is committed), append the emitted token to `website/.npmrc`, run `npm ci` in `website/`, then `git checkout -- website/.npmrc` so autofix-ci never commits the short-lived token.
- **`workflow_call_deploy_doc.yaml`** — `release-doc-action` runs its own `actions/checkout` (clean) and `npm ci` in `website/`, so a workspace `.npmrc` would be wiped. Run `setup-takumi-guard-npm`, then move the token to `~/.npmrc` (outside the workspace) so it survives the checkout; the registry comes from the committed `website/.npmrc`.
- **Thread `TAKUMI_GUARD_BOT_ID` + `id-token: write`** through `workflow_call_test.yaml`, `workflow_call_deploy_doc.yaml` and their callers `test.yaml` / `deploy_doc.yaml`.

Both relocation steps are guarded with `if [ -f .npmrc ]` so they no-op cleanly when the action runs in anonymous mode (e.g. fork PRs where the credential isn't available).

The Go test/build/release workflows don't touch npm and are untouched.

## Prerequisite

A repository/organization secret **`TAKUMI_GUARD_BOT_ID`** (the bot ID issued by Shisho Cloud) must be configured, otherwise OIDC authentication fails (and the website's `npm ci` cannot install from the private registry).

## Validation

- `ghalint run` passes.
- `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
